### PR TITLE
Add local HuggingFace model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ Repository for **Darwin Gödel Machine (DGM)**, a novel self-improving system th
 
 ## Setup
 ```bash
-# API keys, add to ~/.bashrc
+# (Optional) API keys if using remote models
 export OPENAI_API_KEY='...'
 export ANTHROPIC_API_KEY='...'
 ```
+
+The default configuration runs a small local model from Hugging Face and does
+not require any API keys.
 
 ```bash
 # Verify that Docker is properly configured in your environment.

--- a/llm.py
+++ b/llm.py
@@ -6,6 +6,7 @@ import re
 import anthropic
 import backoff
 import openai
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
 
 MAX_OUTPUT_TOKENS = 4096
 AVAILABLE_LLMS = [
@@ -49,6 +50,13 @@ def create_client(model: str):
             base_url="https://api.deepseek.com"
         )
         return client, model
+    elif model.startswith("local/"):
+        local_name = model.split("/", 1)[1]
+        print(f"Using local model {local_name}.")
+        tokenizer = AutoTokenizer.from_pretrained(local_name)
+        model_obj = AutoModelForCausalLM.from_pretrained(local_name)
+        pipe = pipeline("text-generation", model=model_obj, tokenizer=tokenizer)
+        return pipe, local_name
     elif model == "llama3.1-405b":
         print(f"Using OpenAI API with {model}.")
         client = openai.OpenAI(
@@ -265,6 +273,16 @@ def get_response_from_llm(
         content = response.choices[0].message.content
         new_msg_history = new_msg_history + [{"role": "assistant", "content": content}]
         resoning_content = response.choices[0].message.reasoning_content
+    elif model.startswith("local/"):
+        prompt = system_message + "\n" + "\n".join([
+            f"{m['role']}: {m['content']}" for m in msg_history
+        ]) + f"\nuser: {msg}"
+        outputs = client(prompt, max_new_tokens=MAX_OUTPUT_TOKENS, do_sample=True, temperature=temperature)
+        content = outputs[0]["generated_text"][len(prompt):]
+        new_msg_history = msg_history + [
+            {"role": "user", "content": msg},
+            {"role": "assistant", "content": content}
+        ]
     else:
         raise ValueError(f"Model {model} not supported.")
     if print_debug:

--- a/llm_withtools.py
+++ b/llm_withtools.py
@@ -10,8 +10,9 @@ from llm import create_client, get_response_from_llm
 from prompts.tooluse_prompt import get_tooluse_prompt
 from tools import load_all_tools
 
-CLAUDE_MODEL = 'bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0'
-OPENAI_MODEL = 'o3-mini-2025-01-31'
+LOCAL_MODEL = 'local/sshleifer/tiny-gpt2'
+CLAUDE_MODEL = LOCAL_MODEL
+OPENAI_MODEL = LOCAL_MODEL
 
 def process_tool_call(tools_dict, tool_name, tool_input):
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ backoff
 botocore
 boto3
 openai
+transformers
 
 # SWE-Bench
 beautifulsoup4


### PR DESCRIPTION
## Summary
- support local HuggingFace models in the LLM helper
- default to a tiny GPT2 model for all tools
- update docs to note API keys are optional
- add `transformers` to requirements

## Testing
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68729661254883249df84153262e70f1