### PR TITLE
Enable GPU for local models

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ python DGM_outer.py
 ```
 By default, outputs will be saved in the `output_dgm/` directory.
 
+### Running on Raspberry Pi / Jetson Orin Nano
+This repository supports completely offline execution using local Hugging Face models. When running on a Raspberry Pi 5 with a Jetson Orin Nano, ensure that your desired model is downloaded beforehand. The code will automatically use the GPU if it is available.
+
+```python
+device = 0 if torch.cuda.is_available() else -1
+pipeline("text-generation", model=model_obj, tokenizer=tokenizer, device=device)
+```
+
+No network access is required once all dependencies and model weights are installed.
+
 ## File Structure
 - `analysis/` scripts used for plotting and analysis
 - `initial/` SWE-bench logs and performance of the initial agent

--- a/llm.py
+++ b/llm.py
@@ -6,6 +6,7 @@ import re
 import anthropic
 import backoff
 import openai
+import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
 
 MAX_OUTPUT_TOKENS = 4096
@@ -55,7 +56,13 @@ def create_client(model: str):
         print(f"Using local model {local_name}.")
         tokenizer = AutoTokenizer.from_pretrained(local_name)
         model_obj = AutoModelForCausalLM.from_pretrained(local_name)
-        pipe = pipeline("text-generation", model=model_obj, tokenizer=tokenizer)
+        device = 0 if torch.cuda.is_available() else -1
+        pipe = pipeline(
+            "text-generation",
+            model=model_obj,
+            tokenizer=tokenizer,
+            device=device,
+        )
         return pipe, local_name
     elif model == "llama3.1-405b":
         print(f"Using OpenAI API with {model}.")


### PR DESCRIPTION
## Summary
- run local models on GPU when available
- document Jetson/Raspberry Pi usage instructions

## Testing
- `pytest -rA`

------
https://chatgpt.com/codex/tasks/task_e_6873e3e78c3c8324b89d3ba04b18fe22